### PR TITLE
CI/CD(pre-commit): fixed mypy --python-executable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         args: [
           --strict,
           --python-executable,
-            /home/hacker/Documents/projects/weather_app/.venv/bin/python,
+            $(which python),
         ]
 
   - repo: https://github.com/pycqa/isort


### PR DESCRIPTION
It allows mypy to lint in git worktrees too