### PR TITLE
Revert "CI/CD: fix mypy --python-executable in .pre-commit-config.yaml"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         args: [
           --strict,
           --python-executable,
-            /home/hacker/.cache/pypoetry/virtualenvs/weather-app-GGKQ7Kfk-py3.10,
+            /home/hacker/Documents/projects/weather_app/.venv/bin/python,
         ]
 
   - repo: https://github.com/pycqa/isort


### PR DESCRIPTION
This reverts commit 681b59bfaf15ede665e7f5f0def901978782d598.
Need more universal solution.
It should solve next issues:
1) automatically find the python executable path for mypy check in precommit
2) it should work both in --bare and usual git repositories
Now --python-executable argument for mypy is just .venv/bin/python and to set pre-commit linting with mypy you need manually change it on your path.